### PR TITLE
Fix BBOX format in `mesh.py`

### DIFF
--- a/src/pnmol/mesh.py
+++ b/src/pnmol/mesh.py
@@ -109,20 +109,20 @@ class RectangularMesh(Mesh):
 
         if steps is not None:
             step_y, step_x = steps
-            num_y = int((bounding_boxes[0, 1] - bounding_boxes[0, 0]) / step_y) + 1
-            num_x = int((bounding_boxes[1, 1] - bounding_boxes[1, 0]) / step_x) + 1
+            num_y = int((bounding_boxes[1, 0] - bounding_boxes[0, 0]) / step_y) + 1
+            num_x = int((bounding_boxes[1, 1] - bounding_boxes[0, 1]) / step_x) + 1
 
         if nums is not None:
             num_y, num_x = nums
 
         Y = jnp.linspace(
             start=bounding_boxes[0, 0],
-            stop=bounding_boxes[0, 1],
+            stop=bounding_boxes[1, 0],
             num=num_y,
             endpoint=True,
         )
         X = jnp.linspace(
-            start=bounding_boxes[1, 0],
+            start=bounding_boxes[0, 1],
             stop=bounding_boxes[1, 1],
             num=num_x,
             endpoint=True,

--- a/src/pnmol/pde_problems.py
+++ b/src/pnmol/pde_problems.py
@@ -256,12 +256,12 @@ def burgers_2d(
     """
     # Bounding box for spatial discretization grid
     if bbox is None:
-        bbox = [[0.0, 1.0], [0.0, 1.0]]
+        bbox = [[0.0, 0.0], [1.0, 1.0]]
     bbox = jnp.asarray(bbox)
     assert bbox.ndim == 2
 
-    num_y = int((bbox[0, 1] - bbox[0, 0]) / dx) + 1
-    num_x = int((bbox[1, 1] - bbox[1, 0]) / dx) + 1
+    num_y = int((bbox[1, 0] - bbox[0, 0]) / dx) + 1
+    num_x = int((bbox[1, 1] - bbox[0, 1]) / dx) + 1
 
     # Create spatial discretization grid
     grid = mesh.RectangularMesh.from_bounding_boxes_2d(


### PR DESCRIPTION
Before, we had the format specifying extents, i.e.
```
[[0, 1], [0, 1]]
# x         y         extent
```
defined a unit bbox. But if we call it bbox let's stick to the bbox format. Now, a bbox is defined by its top-left and bottom-right corner points. I.e., for a unit bbox, 
```
[[0,0], [1,1]]
```

Adapted the (only) 2D PDE Problem, as well.